### PR TITLE
Add http argument in the start command example

### DIFF
--- a/mindsdb-docs/docs/databases/Clickhouse.md
+++ b/mindsdb-docs/docs/databases/Clickhouse.md
@@ -104,7 +104,7 @@ The avaiable configuration options are:
 To start mindsdb run following command:
 
 ```python
-python3 -m mindsdb --api=mysql --config=config.json
+python3 -m mindsdb --api=http,mysql --config=config.json
 ```
 The --api parameter specifies the type of API to use in this case mysql. 
 The --config specifies the location of the configuration file. 

--- a/mindsdb-docs/docs/databases/MariaDB.md
+++ b/mindsdb-docs/docs/databases/MariaDB.md
@@ -104,7 +104,7 @@ The avaiable configuration options are:
 To start mindsdb run following command:
 
 ```python
-python3 -m mindsdb --api=mysql --config=config.json
+python3 -m mindsdb --api=http,mysql --config=config.json
 ```
 The --api parameter specifies the type of API to use in this case mysql. 
 The --config specifies the location of the configuration file. 

--- a/mindsdb-docs/docs/databases/MySQL.md
+++ b/mindsdb-docs/docs/databases/MySQL.md
@@ -86,7 +86,7 @@ The avaiable configuration options are:
 To start mindsdb run following command:
 
 ```python
-python3 -m mindsdb --api=mysql --config=config.json
+python3 -m mindsdb --api=http,mysql --config=config.json
 ```
 The --api parameter specifies the type of API to use in this case mysql. 
 The --config specifies the location of the configuration file. 

--- a/mindsdb-docs/docs/databases/PostgreSQL.md
+++ b/mindsdb-docs/docs/databases/PostgreSQL.md
@@ -86,7 +86,7 @@ The avaiable configuration options are:
 To start mindsdb run following command:
 
 ```python
-python3 -m mindsdb --api=mysql --config=config.json
+python3 -m mindsdb --api=http,mysql --config=config.json
 ```
 The --api parameter specifies the type of API to use in this case mysql. 
 The --config specifies the location of the configuration file. 


### PR DESCRIPTION
Fixes #
Issue: [mindsdb/mindsdb#793](https://github.com/mindsdb/mindsdb/issues/793)
## Please describe what changes you made in as much detail as possible
  - Changes in this PR adds the http argument to the star commands examples in the documentations of all 4 databases.

