### PR TITLE
Add pre-reqs section to lightwood docs

### DIFF
--- a/mindsdb-docs/docs/lightwood/info.md
+++ b/mindsdb-docs/docs/lightwood/info.md
@@ -7,6 +7,9 @@ Lightwood is a Pytorch based framework with two objectives:
 
 Lightwood was inspired on [Keras](https://keras.io/)+[Ludwig](https://github.com/uber/ludwig) but runs on Pytorch and gives you full control of what you can do.
 
+## Prerequisites
+
+Python >=3.6 64bit version
 
 ## Installing Lightwood
 


### PR DESCRIPTION
Addresses issue reported in the regular mindsdb repo: https://github.com/mindsdb/mindsdb/issues/871

## Please describe what changes you made in as much detail as possible
  - Added a pre-reqs section that mentions needing to have python 3.6+ 64 bit version installed

