### PR TITLE
Removed Ludwig from docs

### DIFF
--- a/mindsdb-docs/docs/InsideMindsDB.md
+++ b/mindsdb-docs/docs/InsideMindsDB.md
@@ -47,7 +47,7 @@ Finally, the various stats are passed on as part of the metadata, so that furthe
 * **Data adaption**: The `ModelInterface` phase is simply a lightweight wrapper over the model [backends](https://github.com/mindsdb/mindsdb_native/tree/stable/mindsdb_native/libs/backends) which handle adapting the data frame used by mindsdb into a format they can work with. During this process additional metadata for the machine learning libraries/frameworks is generated based on the results of the **Stats Generator** phase.
 
 * **Learning backend**: The learning backends as the [ensemble learning](https://en.wikipedia.org/wiki/Ensemble_learning) libraries used by mindsdb to train the model that will generate the predictions.
-Currently the two learning backends we are working on supporting are Ludwig (maintained mainly by Uber, fully supported) and Lightwood (created by us, based on the pre 1.0 version of mindsdb, work in progress).
+Currently the learning backend we are working on supporting is Lightwood (created by us, based on the pre 1.0 version of mindsdb, work in progress).
 
 ## ModelAnalyzer
 


### PR DESCRIPTION
Fixes #

## Please describe what changes you made in as much detail as possible
  -Removed Ludwig from InsideMindsDB. However, as I found out Ludwig implementation still remains in the repo [https://github.com/mindsdb/mindsdb_native/tree/stable/mindsdb_native/libs/backends]. I am new to this so please provide opportunies for corrections.

