### PR TITLE
[BUG] #897 : Changing port number in expanded config

### DIFF
--- a/mindsdb-docs/docs/databases/Clickhouse.md
+++ b/mindsdb-docs/docs/databases/Clickhouse.md
@@ -72,7 +72,7 @@ The avaiable configuration options are:
           "enabled": true,
           "host": "localhost",
           "password": "root",
-          "port": 3307,
+          "port": 8123,
           "type": "mysql",
           "user": "root"
       }


### PR DESCRIPTION
Fixes [#897](https://github.com/mindsdb/mindsdb/issues/897)


## Please describe what changes you made in as much detail as possible

The expanded configuration example had an incorrect port number. Changing it to 8123, the default port for Clickhouse.
  -

