### PR TITLE
Add MySQL and PostgreSQL AI Tables in docs

### DIFF
--- a/mindsdb-docs/docs/databases/Clickhouse.md
+++ b/mindsdb-docs/docs/databases/Clickhouse.md
@@ -2,14 +2,14 @@
 
 Now, you can train machine learning models straight from the database by using MindsDB and [ClickHouse](https://clickhouse.tech/).
 
-![MindsDB-ClickHouse](/assets/clickhouse-mdb-diagram.png)
+![MindsDB-ClickHouse](../assets/clickhouse-mdb-diagram.png)
 
 
 ### Prerequisite
 
 You will need MindsDB version >= 2.0.0 and ClickHouse installed.
 
-* [Install MindsDB](/Installing/)
+* [Install MindsDB](../Installing.md/)
 * [Install ClickHouse](https://clickhouse.tech/docs/en/getting-started/install/)
 
 ### Configuration

--- a/mindsdb-docs/docs/databases/MariaDB.md
+++ b/mindsdb-docs/docs/databases/MariaDB.md
@@ -2,13 +2,13 @@
 
 Now, you can train machine learning models straight from the database by using MindsDB and [MariaDB](https://mariadb.org/).
 
-![MindsDB-ClickHouse](/assets/databases/mdb-maria.png)
+![MindsDB-ClickHouse](../assets/databases/mdb-maria.png)
 
 ### Prerequisite
 
 You will need MindsDB version >= 2.0.0 and MariaDB installed:
 
-* [Install MindsDB](/Installing/)
+* [Install MindsDB](../Installing.md)
 * [Install MariaDB](https://mariadb.com/kb/en/getting-installing-and-upgrading-mariadb/)
 
 ### Configuration

--- a/mindsdb-docs/docs/databases/MySQL.md
+++ b/mindsdb-docs/docs/databases/MySQL.md
@@ -2,13 +2,13 @@
 
 Now, you can train machine learning models straight from the database by using MindsDB and [MySQL](https://www.mysql.com/).
 
-![MindsDB-MySQL](/assets/databases/mdb-mysql.png)
+![MindsDB-MySQL](../assets/databases/mdb-mysql.png)
 
 ### Prerequisite
 
 You will need MindsDB version >= 2.3.0 and MySQL installed:
 
-* [Install MindsDB](/Installing/)
+* [Install MindsDB](../Installing.md)
 * [Install MySQL](https://www.mysql.com/downloads/)
 * [Enable FEDERATED Storage Engine](https://dev.mysql.com/doc/refman/8.0/en/federated-storage-engine.html)
 

--- a/mindsdb-docs/docs/databases/PostgreSQL.md
+++ b/mindsdb-docs/docs/databases/PostgreSQL.md
@@ -2,13 +2,13 @@
 
 Now, you can train machine learning models straight from the database by using MindsDB and [PostgreSQL](https://www.postgresql.org/).
 
-![MindsDB-Postgres](/assets/databases/mdb-postgres.png)
+![MindsDB-Postgres](../assets/databases/mdb-postgres.png)
 
 ### Prerequisite
 
 You will need MindsDB version >= 2.3.0 and PostgreSQL installed:
 
-* [Install MindsDB](/Installing/)
+* [Install MindsDB](../Installing.md)
 * [Install PostgreSQL](https://www.postgresql.org/download/)
 * [Install PostgreSQL foreign data wrapper for MySQL](https://github.com/EnterpriseDB/mysql_fdw#mysql-foreign-data-wrapper-for-postgresql)
 
@@ -103,7 +103,7 @@ INSERT INTO mindsdb.predictors(name, predict, select_data_query, training_option
 * name (string) -- The name of the predictor.
 * predict (string) --  The feature you want to predict, in this example consumption. To predict multiple featurs include a comma separated string e.g 'consumption,income'.
 * select_data_query (string) -- The SELECT query that will ingest the data to train the model.
-* training_options (JSON as comma separated string) -- optional value that contains additional training parameters. For a full list of the parameters check the [PredictorInterface](/PredictorInterface/#learn). If you are using timeseries data check the [Timeseries settings](/tutorials/Timeseries/).
+* training_options (JSON as comma separated string) -- optional value that contains additional training parameters. For a full list of the parameters check the [PredictorInterface](/PredictorInterface/#learn). If you are using timeseries data check the [Timeseries settings](../tutorials/Timeseries.md/).
 
 ### Query the model
 
@@ -185,4 +185,4 @@ The requirements to query with `select_data_query` are:
 * It must be a valid SQL statement
 * It must return columns with names the same as predictor fields.
 
-To get additional information follow the [AiTables in PostgreSQL tutorail](/databases/tutorials/AiTablesInPostgreSQL/).
+To get additional information follow the [AiTables in PostgreSQL tutorail](tutorials/AiTablesInPostgreSQL.md).

--- a/mindsdb-docs/docs/databases/index.md
+++ b/mindsdb-docs/docs/databases/index.md
@@ -2,7 +2,7 @@
 
 Starting from MindsDB 2.0 version you can train machine learning models straight from the database by using MindsDB and the most popular database management systems like MySQL, MariaDB, PostgreSQL, ClickHouse. Any database user can now create, train and test machine learning models with the same knowledge they have of SQL. 
 
-![MindsDB-Databases](/assets/databases/ex-dbs.png)
+![MindsDB-Databases](../assets/databases/ex-dbs.png)
 
 ## AITables example
 
@@ -51,9 +51,11 @@ WHERE  model = "a6"
 
 As you can see with AI-Tables, we are aiming to simplify Machine Learning mechanics to simple SQL queries, so that you can focus on the important part; which is to think about what predictions you need and what data you want your ML to learn from to make such predictions. 
  
-![MindsDB-AutoML in Databases](/assets/databases/db-automl.png)
+![MindsDB-AutoML in Databases](../assets/databases/db-automl.png)
 
 Currently, we are supporting the integration with:
 
-* [MariaDB](/databases/MariaDB)
-* [ClickHouse](/databases/Clickhouse)
+* [MariaDB](MariaDB.md)
+* [ClickHouse](Clickhouse.md)
+* [PostgreSQL](PostgreSQL.md)
+* [MySQL](MySQL.md)


### PR DESCRIPTION
Fixes [#896](https://github.com/mindsdb/mindsdb/issues/896)

Corrected some links to images and markdown files

```diff
- "/assests/databases/...."
+ "../assests/databases/...."
```

Added MySQL, PostgreSQL Support links to the docs.

But I was not sure about the [PredictorInterface](/PredictorInterface/#learn) at [Link](https://github.com/mindsdb/mindsdb-docs/blob/master/mindsdb-docs/docs/databases/MariaDB.md#train-new-model) That was directing to 404 error page.

