### PR TITLE
Update mindsdb_native examples

### DIFF
--- a/mindsdb-docs/docs/tutorials/AdvancedExamples.md
+++ b/mindsdb-docs/docs/tutorials/AdvancedExamples.md
@@ -14,9 +14,9 @@ In the following example, we've altered the real estate model to predict the `lo
 
 ### Code example
 ```python
-import mindsdb
+import mindsdb_native
 
-mdb = mindsdb.Predictor(name='multilabel_real_estate_model')
+mdb = mindsdb_native.Predictor(name='multilabel_real_estate_model')
 mdb.learn(
     from_data="https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv",
     to_predict=['location','neighborhood'] # Array with the names of the columns we want to predict

--- a/mindsdb-docs/docs/tutorials/BasicExample.md
+++ b/mindsdb-docs/docs/tutorials/BasicExample.md
@@ -27,8 +27,6 @@ Predictor(name='real_estate_model').learn(
 ### Predicting
 
 ```python
-mdb = mindsdb_native.Predictor(name='real_estate_model')
-
 # use the model to make predictions
 result = Predictor(name='home_rentals_price').predict(when_data={'number_of_rooms': 1, 'initial_price': 1222, 'sqft': 1190})
 

--- a/mindsdb-docs/docs/tutorials/BasicExample.md
+++ b/mindsdb-docs/docs/tutorials/BasicExample.md
@@ -16,7 +16,7 @@ The goal is to be able to predict the best **rental_price** for new properties g
 from mindsdb_native import Predictor
 
 # We tell the Predictor what column or key we want to learn and from what data
-Predictor(name='real_estate_model').learn(
+Predictor(name='home_rentals_price').learn(
     from_data="https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv", # the path to the file where we can learn from, (note: can be url)
     to_predict='rental_price', # the column we want to learn to predict given all the data in the file
 )

--- a/mindsdb-docs/docs/tutorials/BasicExample.md
+++ b/mindsdb-docs/docs/tutorials/BasicExample.md
@@ -13,7 +13,7 @@ The goal is to be able to predict the best **rental_price** for new properties g
 ### Learning
 
 ```python
-from mindsdb import Predictor
+from mindsdb_native import Predictor
 
 # We tell the Predictor what column or key we want to learn and from what data
 Predictor(name='real_estate_model').learn(
@@ -27,7 +27,7 @@ Predictor(name='real_estate_model').learn(
 ### Predicting
 
 ```python
-mdb = mindsdb.Predictor(name='real_estate_model')
+mdb = mindsdb_native.Predictor(name='real_estate_model')
 
 # use the model to make predictions
 result = Predictor(name='home_rentals_price').predict(when_data={'number_of_rooms': 1, 'initial_price': 1222, 'sqft': 1190})

--- a/mindsdb-docs/docs/tutorials/ChurnReduction.md
+++ b/mindsdb-docs/docs/tutorials/ChurnReduction.md
@@ -47,14 +47,14 @@ tenureNumber of months the customer has stayed with the company
 
 ## MindsDB Code example
 ```python
-import mindsdb
+import mindsdb_native
 import pandas as pd
 from sklearn.metrics import accuracy_score
 
 
 def run():
 
-    mdb = mindsdb.Predictor(name='employee_retention_model')
+    mdb = mindsdb_native.Predictor(name='customer_churn_model')
 
     mdb.learn(from_data='dataset/train.csv', to_predict='Churn')
 
@@ -73,7 +73,6 @@ def run():
     return {
         'accuracy': accuracy,
         'accuracy_function': 'accuracy_score',
-        'backend': backend,
         'prediction_per_row': additional_info
     }
 

--- a/mindsdb-docs/docs/tutorials/CreditScoring.md
+++ b/mindsdb-docs/docs/tutorials/CreditScoring.md
@@ -142,12 +142,12 @@ The German Credit dataset is a publically available from the [UCI Machine Learni
 
 ## MindsDB Code example
 ```python
-from mindsdb import Predictor
+from mindsdb_native import Predictor
 import pandas as pd
-from sklearn.metrics import balanced_accuracy_score, confusion_matrix
+from sklearn.metrics import balanced_accuracy_score
 
 
-def run(sample=False):
+def run():
 
     mdb = Predictor(name='german_data')
 

--- a/mindsdb-docs/docs/tutorials/CustomerLifetimeValue.md
+++ b/mindsdb-docs/docs/tutorials/CustomerLifetimeValue.md
@@ -22,14 +22,14 @@ This is a [dataset](http://ai.stanford.edu/~amaas/data/sentiment/) for binary se
 ## MindsDB Code example
 
 ```python
-import mindsdb
+import mindsdb_native
 from sklearn.metrics import accuracy_score
 
 
-predictor = mindsdb.Predictor(name='movie_sentiment_predictor')
+predictor = mindsdb_native.Predictor(name='movie_sentiment_predictor')
 predictor.learn(from_data='train.tsv', to_predict=['sentiment'])
 
-accuracy_data = predictions.test('test.tsv', accuracy_score)
+accuracy_data = predictor.test('test.tsv', accuracy_score)
 
 accuracy_pct = accuracy_data['sentiment_accuracy'] * 100
 print(f'Accuracy of {accuracy_pct}% !')

--- a/mindsdb-docs/docs/tutorials/FraudDetection.md
+++ b/mindsdb-docs/docs/tutorials/FraudDetection.md
@@ -58,20 +58,20 @@ This dataset presents transactions that occurred in two days, where we have 492 
 ## MindsDB Code example
 
 ```python
-import mindsdb
+import mindsdb_native
 import pandas as pd
 from sklearn.metrics import balanced_accuracy_score
 
 def run():
 
-    mdb = mindsdb.Predictor(name='cc_fraud')
+    mdb = mindsdb_native.Predictor(name='cc_fraud')
 
     mdb.learn(from_data='processed_data/train.csv', to_predict='Class')
 
     predictions = mdb.predict(when_data='processed_data/test.csv')
 
     pred_val = [int(x['Class']) for x in predictions]
-    real_val = [int(x) for x in list(pd.read_csv('processed_data/test.csv'))['Class'])]
+    real_val = [int(x) for x in list(pd.read_csv('processed_data/test.csv'))['Class']]
 
     accuracy = balanced_accuracy_score(real_val, pred_val)
 
@@ -80,7 +80,6 @@ def run():
       
     return {
         'accuracy': accuracy,
-        'backend': backend,
         'additional info': additional_info
     }
 

--- a/mindsdb-docs/docs/tutorials/HotelBooking.md
+++ b/mindsdb-docs/docs/tutorials/HotelBooking.md
@@ -61,7 +61,7 @@ adrAverage Daily Rate as defined by dividing the sum of all lodging transactions
 
 ## MindsDB Code example
 ```python
-import mindsdb
+import mindsdb_native
 import sys
 import pandas as pd
 from sklearn.metrics import balanced_accuracy_score
@@ -69,12 +69,12 @@ from sklearn.metrics import balanced_accuracy_score
 
 def run():
 
-    mdb = mindsdb.Predictor(name='hotel_booking')
+    mdb = mindsdb_native.Predictor(name='hotel_booking')
 
-    mdb.learn(from_data='dataset/train.csv', to_predict='is_canceled')
+    mdb.learn(from_data='processed_data/train.csv', to_predict='is_canceled')
 
-    test_df = pd.read_csv('dataset/test.csv')
-    predictions = mdb.predict(when_data='dataset/test.csv')
+    test_df = pd.read_csv('processed_data/test.csv')
+    predictions = mdb.predict(when_data='processed_data/test.csv')
 
     results = [str(x['is_canceled']) for x in predictions]
     real = list(map(str, list(test_df['is_canceled'])))
@@ -87,7 +87,6 @@ def run():
     return {
         'accuracy': accuracy,
         'accuracy_function': 'balanced_accuracy_score',
-        'backend': backend,
         'additional_info': additional_info
     }
 

--- a/mindsdb-docs/docs/tutorials/MedicalDiagnosis.md
+++ b/mindsdb-docs/docs/tutorials/MedicalDiagnosis.md
@@ -55,14 +55,14 @@ concave points_sestandard error for number of concave portions of the contour
 
 ## MindsDB Code example
 ```python
-import mindsdb
+import mindsdb_native
 import sys
 import pandas as pd
 from sklearn.metrics import balanced_accuracy_score
 
 
-def run(sample):
-    mdb = mindsdb.Predictor(name='cancer_model')
+def run():
+    mdb = mindsdb_native.Predictor(name='cancer_model')
 
     mdb.learn(from_data='processed_data/train.csv', to_predict='diagnosis')
 
@@ -77,12 +77,10 @@ def run(sample):
     return {
         'accuracy': accuracy
         ,'accuracy_function': 'balanced_accuracy_score'
-        ,'backend': backend
     }
 
 if __name__ == '__main__':
-    sample = bool(sys.argv[1]) if len(sys.argv) > 1 else False
-    result = run(sample)
+    result = run()
     print(result)
 ```
 

--- a/mindsdb-docs/docs/tutorials/PatientHealthOutcomes.md
+++ b/mindsdb-docs/docs/tutorials/PatientHealthOutcomes.md
@@ -51,12 +51,12 @@ In the Heart Disease UCI dataset, the data comes from 4 databases: the Hungarian
 
 ## MindsDB Code example
 ```python
-import mindsdb
+import mindsdb_native
 import pandas as pd
 from sklearn.metrics import balanced_accuracy_score
 
 def run():
-    mdb = mindsdb.Predictor(name='hd')
+    mdb = mindsdb_native.Predictor(name='hd')
 
     mdb.learn(from_data='processed_data/train.csv', to_predict='target')
 

--- a/mindsdb-docs/docs/tutorials/PredictiveMaintenance.md
+++ b/mindsdb-docs/docs/tutorials/PredictiveMaintenance.md
@@ -35,13 +35,13 @@ Fx1 ... Fx15 is the evolution of force Fx in the observation window
 </details>
 
 ```python
-import mindsdb
+import mindsdb_native
 import pandas as pd
 from sklearn.metrics import r2_score
 
 
 def run():
-    mdb = mindsdb.Predictor(name='robotic_failure')
+    mdb = mindsdb_native.Predictor(name='robotic_failure')
 
     mdb.learn(from_data='dataset/train.csv', to_predict=['target'])
 

--- a/mindsdb-docs/docs/tutorials/Timeseries.md
+++ b/mindsdb-docs/docs/tutorials/Timeseries.md
@@ -34,9 +34,9 @@ Let's go through these settings one by one:
 ### Code example
 
 ```python
-import mindsdb
+import mindsdb_native
 
-mdb = mindsdb.Predictor(name='assembly_machines_model')
+mdb = mindsdb_native.Predictor(name='assembly_machines_model')
 mdb.learn(
     from_data='assembly_machines_historical_data.tsv',
     to_predict='failure',
@@ -45,7 +45,7 @@ mdb.learn(
       'group_by': ['machine_id'], # The ordering should be done on a per-machine basis, rather than for every single row
       'nr_predictions': 3, # Predict failures for the timestamp given and for 2 more timesteps in the future
       'use_previous_target': True, # Use the previous values in the target column (`failure`), since when the last failure happened could be a relevant data-point for our prediction.
-      'window': 20 # Consider the previous 20 rows for every single row our model is trying to predict
+      'window': 20, # Consider the previous 20 rows for every single row our model is trying to predict
       'historical_columns': ['sensor_activity'] # Mark `sensor_activity` column as historical, to use its temporal dynamics as additional context
     }
 )


### PR DESCRIPTION
This fixes some typos in the examples in the documentation so that the examples are runnable. Mostly just renames `mindsdb` to `mindsdb_native`, also removed some unused (not existing) variables and imports.

Result if you try the code in the existing [documentation](https://docs.mindsdb.com/tutorials/BasicExample/): 
```shell
Python 3.7.8 (default, Jul 16 2020, 22:30:43) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import mindsdb
 ✓ telemetry enabled 
>>> mindsdb.__version__
'2.35.0'
>>> from mindsdb import Predictor
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'Predictor' from 'mindsdb' 
```

